### PR TITLE
Remove USP mention from CodeLab Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 ## Introduction
 
-The **USPCodeLab Handbook** is, primarily, a repository of all relevant information about _USPCodeLab_, an universitary extension group which aims to stimulate technological innovation at the _University of São Paulo_. Here you can find more information about the group, initiatives, projects, internal organization and much more. Although it was created to _improve the onboarding experience of new members_, the **Handbook is open for everyone to read :)**
+The **CodeLab Handbook** is, primarily, a repository of all relevant information about _CodeLab_, an universitary extension group which aims to stimulate technological innovation. Here you can find more information about the group, initiatives, projects, internal organization and much more. Although it was created to _improve the onboarding experience of new members_, the **Handbook is open for everyone to read :)**
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Hello World - USPCodeLab (Pão)
+# Hello World - CodeLab (Pão)
 
 ## Discord 101
 ::: tip
@@ -99,7 +99,7 @@ CLI? CLASS? CLAP? CLUB? LUH? Mas que p#$!@ é essa?!<br/>
 Talvez você já deva ter se deparado com alguma sigla misteriosa presente em qualquer lugar que seja, nesta seção tentamos dar uma luz quanto ao significado de cada acrônimo utilizado pelo CodeLab. A seguir listamos as principais e um breve resumo de cada uma.
 :::
 
-- **CLI** (*CodeLab Iniative*): se trata de uma iniciativa em espalhar a "palavra" CodeLab por outras unidades da USP e quem sabe outras universidades. Além de, principalmente, promover a união entre o grupo como um todo.
+- **CLI** (*CodeLab Iniative*): se trata de uma iniciativa em espalhar a "palavra" CodeLab por outras unidades da USP e outras universidades. Além de, principalmente, promover a união entre o grupo como um todo.
 - **LUH** (Liga Universitária de Hackathon): se trata do englobamento dos Hackathons, Hackdays, Hackfests organizados pelo nosso grupo. https://uclab.xyz/luh
 - **CLASS** (*CodeLab Association*): se trata de uma associação sem fins lucrativos que estamos tentando criar para o grupo, o que facilitará muitos processos burocráticos do grupo, sobretudo, do que se trata a patrocínios, pois passaremos a ter um CNPJ.
 - **CLUB** (*CodeLab University Bureau*): se trata de um plano para encontrarmos uma sala fixa, para concentramos nossas atividades em um único local em cada unidade.


### PR DESCRIPTION
Since we are branching to more universities, we should make a more neutral handbook.